### PR TITLE
Fix local storage JS errors

### DIFF
--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -29,10 +29,7 @@ export function ThemeProvider({
   storageKey = "vite-ui-theme",
   ...props
 }: ThemeProviderProps) {
-  // const [theme, setTheme] = useState<Theme>(
-  //   () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
-  // );
-
+  
   const [theme, setTheme] = useLocalStorage(storageKey, defaultTheme);
 
   useEffect(() => {

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createContext, useContext, useEffect } from "react";
-import { useLocalStorage } from "src/hooks/useLocalStorage";
+import { useLocalStorage } from "~/hooks/useLocalStorage";
 
 type Theme = "dark" | "light" | "system";
 

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect } from "react";
+import { useLocalStorage } from "src/hooks/useLocalStorage";
 
 type Theme = "dark" | "light" | "system";
 
 type ThemeProviderProps = {
   children: React.ReactNode;
-  defaultTheme?: Theme;
+  defaultTheme: Theme;
   storageKey?: string;
 };
 
@@ -28,9 +29,11 @@ export function ThemeProvider({
   storageKey = "vite-ui-theme",
   ...props
 }: ThemeProviderProps) {
-  const [theme, setTheme] = useState<Theme>(
-    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
-  );
+  // const [theme, setTheme] = useState<Theme>(
+  //   () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
+  // );
+
+  const [theme, setTheme] = useLocalStorage(storageKey, defaultTheme);
 
   useEffect(() => {
     const root = window.document.documentElement;

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -7,7 +7,7 @@ type Theme = "dark" | "light" | "system";
 
 type ThemeProviderProps = {
   children: React.ReactNode;
-  defaultTheme: Theme;
+  defaultTheme?: Theme;
   storageKey?: string;
 };
 

--- a/src/hooks/useLocalStorage.tsx
+++ b/src/hooks/useLocalStorage.tsx
@@ -1,0 +1,32 @@
+import { useState } from "react";
+
+export const useLocalStorage = <T extends string>(
+  key: string,
+  initialValue: T,
+): [T, (value: T | ((val: T) => T)) => void] => {
+  const [state, setState] = useState<T>(() => {
+    if (typeof window !== "undefined") {
+      try {
+        const value = window.localStorage.getItem(key);
+        return value ? (JSON.parse(value) as T) : initialValue;
+      } catch (error) {
+        console.log(error);
+      }
+    }
+    return initialValue;
+  });
+
+  const setValue = (value: T | ((val: T) => T)) => {
+    if (typeof window !== "undefined") {
+      try {
+        const valueToStore = value instanceof Function ? value(state) : value;
+        window.localStorage.setItem(key, JSON.stringify(valueToStore));
+        setState(valueToStore);
+      } catch (error) {
+        console.log(error);
+      }
+    }
+  };
+
+  return [state, setValue];
+};


### PR DESCRIPTION
Created a `useLocalStorage` hook that checks for window before running. This avoids runtime NextJS errors 


<img width="321" alt="Screenshot 2024-02-19 at 11 55 12 PM" src="https://github.com/iamtheozzy/steward/assets/29648040/d308e219-e238-48da-b8b5-34ee14942d33">
